### PR TITLE
script.js: item instead collection

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,7 +62,7 @@ function plugin_hidden_atLeastOneHidden(){
  * Check if a given element is hidden
  */
 function plugin_hidden_isHidden(elem){
-    return jQuery(elem.parentNode).children('div.hiddenBody').style.display === "none";
+    return jQuery(elem.parentNode).children('div.hiddenBody')[0].style.display === "none";
 }
 
 /**


### PR DESCRIPTION
++ What: in **plugin_hidden_isHidden**, changing ".children('div.hiddenBody')" to ".children('div.hiddenBody')[0]" so that the "===" compare runs over an item instead of the collection
++ Why: I'd suppose that you cannot compare by "===" to collections ... (nor would that be the idea behind the code, i.e. "return true if (and only if) all items are hidden", you are rather searching for "at least one item")
++ Note: Compare with Fabrizio's remarks on https://www.dokuwiki.org/plugin:hiddenswitch (2011/12/03 11:30)
