### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -9,7 +9,7 @@ if(!defined('DOKU_INC')) die();
 require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_hidden extends Dokuwiki_Action_Plugin {
-  function register(&$controller) {
+  function register(Doku_Event_Handler $controller) {
     $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array ());
   }
 

--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_hidden extends DokuWiki_Syntax_Plugin {
     $this->Lexer->addExitPattern('</hidden>','plugin_hidden');
   }
 
-  function handle($match, $state, $pos, &$handler) {
+  function handle($match, $state, $pos, Doku_Handler $handler) {
     switch ($state) {
       case DOKU_LEXER_SPECIAL:
         //hiddenSwitch
@@ -163,7 +163,7 @@ class syntax_plugin_hidden extends DokuWiki_Syntax_Plugin {
     }
   }
 
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
     if ( $this->_exportingPDF() ){
       $data['onVisible'] = $data['onExportPdf'];
     }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.